### PR TITLE
Added a way to get the raw connection from RedisDB

### DIFF
--- a/snaplet-redis.cabal
+++ b/snaplet-redis.cabal
@@ -1,5 +1,5 @@
 Name:                snaplet-redis
-Version:             0.1.1.1
+Version:             0.1.2.1
 Synopsis:            Redis support for Snap Framework
 Description:         This package provides a snaplet which exposes
                      interface to Redis in-memory key-value storage as

--- a/src/Snap/Snaplet/RedisDB.hs
+++ b/src/Snap/Snaplet/RedisDB.hs
@@ -11,6 +11,7 @@ Redis DB snaplet.
 module Snap.Snaplet.RedisDB
     (RedisDB
     , runRedisDB
+    , redisConnection
     , redisDBInit
     , redisDBInitConf)
 
@@ -35,6 +36,10 @@ data RedisDB = RedisDB
 
 makeLenses ''RedisDB
 
+------------------------------------------------------------------------------
+-- | A lens to retrieve the connection to redis from the 'RedisDB' wrapper.
+redisConnection :: Simple Lens RedisDB Connection
+redisConnection = connection
 
 ------------------------------------------------------------------------------
 -- | Perform action using Redis connection from RedisDB snaplet pool
@@ -56,7 +61,7 @@ runRedisDB snaplet action = do
 -- of the Redis snaplet config (e.g. ./snaplets/redis/devel.cfg).
 --
 -- Every field is optional and defaults to defaultConnectInfo values.
--- 
+--
 -- > redis {
 -- >     host = "192.168.0.42"
 -- >     port = 31415


### PR DESCRIPTION
When attempting to write a RedisDB authentication snaplet, I ran into trouble because there's no way for me to run any redis commands from RedisDB in the IO monad.

Consider http://hackage.haskell.org/packages/archive/snap/0.12.0/doc/html/Snap-Snaplet-Auth.html#t:IAuthBackend .

I would like to initialize a redis db snaplet, then pass the connection it creates to the redis authentication snaplet. This patch provides such a mechanism.

If there's a better way to do this, let me know.
