### PR TITLE
Widen dependency on lens and snap.

### DIFF
--- a/snaplet-redis.cabal
+++ b/snaplet-redis.cabal
@@ -32,10 +32,10 @@ Library
   Build-depends:
     base                >= 4 && < 5,
     configurator        >= 0.2 && < 0.4,
-    lens                >= 3.8 && < 4.8,
+    lens                >= 3.8 && < 4.10,
     hedis               == 0.6.*,
     mtl                 >= 2 && < 3,
     network             >= 2.4 && < 2.7,
-    snap                >= 0.11 && < 0.14,
+    snap                >= 0.11 && < 0.15,
     transformers        >= 0.3 && < 0.5,
     text                >= 0.9 && < 1.3


### PR DESCRIPTION
This package builds happily with snap 0.14 and lens 4.9 (which are both what are currently on stackage nightly). This pull request just widens the bounds so those dependencies are permitted.